### PR TITLE
Added the option to set the operator's eth account from the environment.

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,7 +5,6 @@ const {recoverTypedSignature_v4} = require('eth-sig-util');
 debug.enabled = true;
 
 const EventEmitter = require('events');
-const Web3 = require('web3');
 const forge = require('node-forge');
 const EthCrypto = require('eth-crypto');
 
@@ -43,8 +42,8 @@ if (typeof window === 'undefined') {
 const SaladContract = require('../../build/smart_contracts/Salad.json');
 
 class CoinjoinClient {
-    constructor(operatorUrl = 'ws://localhost:8080', provider = Web3.givenProvider) {
-        this.web3 = new Web3(provider);
+    constructor(operatorUrl = 'ws://localhost:8080', web3) {
+        this.web3 = web3;
         this.ws = new WebSocket(operatorUrl);
         this.isConnected = new Promise((resolve) => {
             const callback = () => {

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -197,7 +197,6 @@ class CoinjoinClient {
             null,  // We don't need to access the enigma network
             {
                 gas: 4712388,
-                gasPrice: 100000000000,
                 from: this.accounts[0],
             },
         );

--- a/integration_tests/integration.test.js
+++ b/integration_tests/integration.test.js
@@ -20,10 +20,10 @@ describe('Salad', () => {
     // const anonSetSize = threshold;
     const provider = new Web3.providers.HttpProvider(`http://${process.env.ETH_HOST}:${process.env.ETH_PORT}`);
     const operatorUrl = `ws://${process.env.OPERATOR_HOST}:${process.env.WS_PORT}`;
-    // const web3 = new Web3(provider);
+    const web3 = new Web3(provider);
 
     before(async () => {
-        salad = new CoinjoinClient(operatorUrl, provider);
+        salad = new CoinjoinClient(operatorUrl, web3);
         await salad.initAsync();
 
         process.on('SIGINT', async () => {

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -18,10 +18,6 @@ const provider = new Web3.providers.HttpProvider(`http://${process.env.ETH_HOST}
 const web3 = new Web3(provider);
 let enigma = null;
 
-function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 let SECRET_CONTRACT_BUILD_FOLDER = process.env.SECRET_CONTRACT_BUILD_FOLDER || '../build/secret_contracts';
 
 function getEnigmaContractAddressFromJson() {
@@ -74,7 +70,7 @@ async function deploySecretContract(config, saladAddr, enigmaAddr, enigmaTokenAd
     // Waiting for a worker to register with the enigma network:
     while (true) {
         debug('waiting for a worker to register to the enigma network');
-        await sleep(5000);
+        await utils.sleep(5000);
         const blockNumber = await web3.eth.getBlockNumber();
         const worker_params = await enigma.getWorkerParams(blockNumber);
         debug('worker params := ' + JSON.stringify(worker_params));
@@ -93,7 +89,7 @@ async function deploySecretContract(config, saladAddr, enigmaAddr, enigmaTokenAd
     // Wait for the confirmed deploy contract task
     do {
         debug('waiting for the secret contract to finish deploying.');
-        await sleep(5000);
+        await utils.sleep(5000);
         try {
             scTask = await enigma.getTaskRecordStatus(scTask);
         } catch (e) {

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -65,7 +65,6 @@ async function deploySecretContract(config, saladAddr, enigmaAddr, enigmaTokenAd
         'http://' + enigmaHost + ':' + enigmaPort,
         {
             gas: 4712388,
-            gasPrice: 1e+11,
             from: config.from,
         },
     );

--- a/operator/src/api.js
+++ b/operator/src/api.js
@@ -36,7 +36,6 @@ class OperatorApi {
         this.txOpts = {
             gas: 100712388,
             gasPrice: process.env.GAS_PRICE,
-            from: web3.eth.defaultAccount,
         };
     }
 

--- a/operator/src/api.js
+++ b/operator/src/api.js
@@ -17,10 +17,10 @@ const {recoverTypedSignature_v4} = require('eth-sig-util');
 
 // TODO: Consider moving to config
 const GET_ENCRYPTION_PUB_KEY_GAS_PRICE = 0.001;
-const GET_ENCRYPTION_PUB_KEY_GAS_LIMIT = 4712388;
+const GET_ENCRYPTION_PUB_KEY_GAS_LIMIT = 1000;
 const EXECUTE_DEAL_GAS_PRICE = 0.001;
-const EXECUTE_DEAL_BASE_GAS_UNIT = 6000000;
-const EXECUTE_DEAL_PARTICIPANT_GAS_UNIT = 24000000;
+const EXECUTE_DEAL_BASE_GAS_UNIT = 600;
+const EXECUTE_DEAL_PARTICIPANT_GAS_UNIT = 2400;
 
 class OperatorApi {
     constructor(web3, enigmaUrl, contractAddr, scAddr, threshold, pauseOnRetryInSeconds = 10) {

--- a/operator/src/api.js
+++ b/operator/src/api.js
@@ -20,8 +20,6 @@ const GET_ENCRYPTION_PUB_KEY_GAS_LIMIT = 0.05e+8;
 const EXECUTE_DEAL_BASE_GAS_UNIT = 0.05e+8;
 const EXECUTE_DEAL_PARTICIPANT_GAS_UNIT = 1e+8;
 
-const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
-
 class OperatorApi {
     constructor(web3, enigmaUrl, contractAddr, scAddr, threshold, pauseOnRetryInSeconds = 10) {
         this.store = new Store();
@@ -205,7 +203,7 @@ class OperatorApi {
                     depositsVerifiedSuccess = true;
                 } catch (e) {
                     debug('Unable to verify deposits on Enigma, submitting new Task.', e);
-                    await sleep(30000);
+                    await utils.sleep(30000);
                 }
             } while (!depositsVerifiedSuccess);
         }

--- a/operator/src/api.js
+++ b/operator/src/api.js
@@ -1,7 +1,6 @@
 const {SecretContractClient} = require("./secretContractClient");
 const {Store} = require("./store");
 const {DEAL_CREATED_UPDATE, DEAL_EXECUTED_UPDATE, QUORUM_UPDATE, BLOCK_UPDATE, THRESHOLD_UPDATE, SUBMIT_DEPOSIT_METADATA_RESULT, SUBMIT_DEPOSIT_METADATA_ERROR, FETCH_FILLABLE_SUCCESS, QUORUM_NOT_REACHED_UPDATE, FETCH_CONFIG_SUCCESS} = require("@salad/client").actions;
-const Web3 = require('web3');
 const {DealManager} = require("./dealManager");
 const {utils} = require('enigma-js/node');
 const EventEmitter = require('events');
@@ -16,11 +15,11 @@ const {recoverTypedSignature_v4} = require('eth-sig-util');
  */
 
 // TODO: Consider moving to config
-const GET_ENCRYPTION_PUB_KEY_GAS_PRICE = 0.001;
-const GET_ENCRYPTION_PUB_KEY_GAS_LIMIT = 1000;
-const EXECUTE_DEAL_GAS_PRICE = 0.001;
-const EXECUTE_DEAL_BASE_GAS_UNIT = 600;
-const EXECUTE_DEAL_PARTICIPANT_GAS_UNIT = 2400;
+const GET_ENCRYPTION_PUB_KEY_GAS_PRICE = 1e-8;
+const GET_ENCRYPTION_PUB_KEY_GAS_LIMIT = 0.05e+8;
+const EXECUTE_DEAL_GAS_PRICE = 1e-8;
+const EXECUTE_DEAL_BASE_GAS_UNIT = 0.05e+8;
+const EXECUTE_DEAL_PARTICIPANT_GAS_UNIT = 1e+8;
 
 class OperatorApi {
     constructor(web3, enigmaUrl, contractAddr, scAddr, threshold, pauseOnRetryInSeconds = 10) {

--- a/operator/src/api.js
+++ b/operator/src/api.js
@@ -15,9 +15,8 @@ const {recoverTypedSignature_v4} = require('eth-sig-util');
  */
 
 // TODO: Consider moving to config
-const GET_ENCRYPTION_PUB_KEY_GAS_PRICE = 1e-8;
+const ENG_GAS_PRICE = process.env.ENG_GAS_PRICE || 1e-8;
 const GET_ENCRYPTION_PUB_KEY_GAS_LIMIT = 0.05e+8;
-const EXECUTE_DEAL_GAS_PRICE = 1e-8;
 const EXECUTE_DEAL_BASE_GAS_UNIT = 0.05e+8;
 const EXECUTE_DEAL_PARTICIPANT_GAS_UNIT = 1e+8;
 
@@ -175,7 +174,7 @@ class OperatorApi {
         const participantMultiplier = deposits.length || 1;
         const taskRecordOpts = {
             taskGasLimit: EXECUTE_DEAL_BASE_GAS_UNIT + (participantMultiplier * EXECUTE_DEAL_PARTICIPANT_GAS_UNIT),
-            taskGasPx: utils.toGrains(EXECUTE_DEAL_GAS_PRICE),
+            taskGasPx: utils.toGrains(ENG_GAS_PRICE),
         };
         debug('Updating the last mix block number');
         await this.dealManager.updateLastMixBlockNumberAsync();
@@ -225,7 +224,7 @@ class OperatorApi {
         debug('Sending encryption public key to new connected client');
         const taskRecordOpts = {
             taskGasLimit: GET_ENCRYPTION_PUB_KEY_GAS_LIMIT,
-            taskGasPx: utils.toGrains(GET_ENCRYPTION_PUB_KEY_GAS_PRICE),
+            taskGasPx: utils.toGrains(ENG_GAS_PRICE),
         };
         /** @type EncryptionPubKey|null */
         let pubKeyData = await this.store.fetchPubKeyData();

--- a/operator/src/api.js
+++ b/operator/src/api.js
@@ -23,10 +23,10 @@ const EXECUTE_DEAL_BASE_GAS_UNIT = 6000000;
 const EXECUTE_DEAL_PARTICIPANT_GAS_UNIT = 24000000;
 
 class OperatorApi {
-    constructor(provider, enigmaUrl, contractAddr, scAddr, threshold, accountIndex = 0, pauseOnRetryInSeconds = 10) {
+    constructor(web3, enigmaUrl, contractAddr, scAddr, threshold, pauseOnRetryInSeconds = 10) {
         this.store = new Store();
-        this.web3 = new Web3(provider);
-        this.sc = new SecretContractClient(this.web3, scAddr, enigmaUrl, accountIndex);
+        this.web3 = web3;
+        this.sc = new SecretContractClient(this.web3, scAddr, enigmaUrl);
         this.defaultTaskRecordOpts = {taskGasLimit: 4712388, taskGasPx: 100000000000};
         this.dealManager = new DealManager(this.web3, this.sc, contractAddr, this.store, threshold);
         this.ee = new EventEmitter();

--- a/operator/src/api.js
+++ b/operator/src/api.js
@@ -37,6 +37,7 @@ class OperatorApi {
         this.txOpts = {
             gas: 100712388,
             gasPrice: process.env.GAS_PRICE,
+            from: web3.eth.defaultAccount,
         };
     }
 

--- a/operator/src/dealManager.js
+++ b/operator/src/dealManager.js
@@ -78,7 +78,7 @@ class DealManager {
     async verifyDepositAmountAsync(sender, amount) {
         debug('Verifying balance for deposit', sender, amount);
         const account = this.web3.utils.toChecksumAddress(sender);
-        const balance = await this.contract.methods.getParticipantBalance(account).call({from: this.scClient.getOperatorAccount()});
+        const balance = await this.contract.methods.getParticipantBalance(account).call();
         debug('Comparing balance with amount', balance, amount);
         const senderBalance = this.web3.utils.toBN(balance);
         const depositAmount = this.web3.utils.toBN(amount);
@@ -134,7 +134,6 @@ class DealManager {
         const receipt = await this.contract.methods.newDeal(depositAmount, participants, nonce).send({
             ...opts,
             gas: this.gasValues.createDeal,
-            from: sender,
         });
         const receiptDealId = receipt.events.NewDeal.returnValues._dealId;
         if (receiptDealId !== dealId) {

--- a/operator/src/dealManager.js
+++ b/operator/src/dealManager.js
@@ -50,7 +50,7 @@ class DealManager {
         this.scClient = scClient;
         this.store = store;
         this.threshold = threshold;
-        this.contract = new this.web3.eth.Contract(SaladContract['abi'], contractAddr);
+        this.contract = new this.web3.eth.Contract(SaladContract['abi'], contractAddr, {from: this.web3.eth.defaultAccount});
         this.gasValues = gasValues;
     }
 

--- a/operator/src/dealManager.js
+++ b/operator/src/dealManager.js
@@ -42,14 +42,13 @@ const DEPOSIT_AMOUNT = '0.01';
  * Coordinate deal execution
  */
 class DealManager {
-    constructor(web3, scClient, contractAddr, store, threshold, gasValues = {
+    constructor(web3, scClient, contractAddr, store, gasValues = {
         createDeal: 4712388,
         fetchPubKey: 4712388,
     }) {
         this.web3 = web3;
         this.scClient = scClient;
         this.store = store;
-        this.threshold = threshold;
         this.contract = new this.web3.eth.Contract(SaladContract['abi'], contractAddr, {from: this.web3.eth.defaultAccount});
         this.gasValues = gasValues;
     }
@@ -111,7 +110,7 @@ class DealManager {
      * @param {Object} opts - Ethereum tx options
      * @returns {Promise<Deal>}
      */
-    async createDealAsync(depositAmount, deposits, opts) {
+    async createDealAsync(depositAmount, deposits) {
         const pendingDeals = await this.store.queryDealsAsync(DEAL_STATUS.EXECUTABLE);
         if (pendingDeals.length > 0) {
             debug('The executable deals', pendingDeals);
@@ -132,7 +131,6 @@ class DealManager {
         const deal = {dealId, depositAmount, participants, nonce, status: DEAL_STATUS.NEW, _tx: null, taskId: null};
         await this.store.insertDealAsync(deal, participants);
         const receipt = await this.contract.methods.newDeal(depositAmount, participants, nonce).send({
-            ...opts,
             gas: this.gasValues.createDeal,
         });
         const receiptDealId = receipt.events.NewDeal.returnValues._dealId;

--- a/operator/src/index.js
+++ b/operator/src/index.js
@@ -25,6 +25,7 @@ async function configureWeb3Account(web3) {
             throw new Error("Could not find or generate available account!")
         }
     }
+    debug(`Using the following ethereum account for the operator: ${address}`);
     web3.eth.defaultAccount = address;
     return address;
 }

--- a/operator/src/index.js
+++ b/operator/src/index.js
@@ -7,8 +7,31 @@ const {Store} = require("./store");
 
 const port = process.env.WS_PORT;
 
-async function startServer(provider, enigmaUrl, contractAddr, scAddr, threshold, accountIndex = 0) {
-    const api = new OperatorApi(provider, enigmaUrl, contractAddr, scAddr, threshold, accountIndex);
+// This method tries to create an ethereum account from a private key provided from the environment.
+// If no private key is found, it attempts to fetch the unlocked accounts from the ethereum node,
+// and chooses the first one.
+// If that fails too, an error is thrown.
+async function configureWeb3Account(web3) {
+    let address;
+    if (process.env.OPERATOR_ETH_PRIVATE_KEY) {
+        const account = web3.eth.accounts.privateKeyToAccount(process.env.OPERATOR_PRIVATE_KEY);
+        web3.eth.accounts.wallet.add(account);
+        address = account.address;
+    } else {
+        const accounts = await web3.eth.getAccounts();
+        if (accounts.length > 0) {
+            address = accounts[0];
+        } else {
+            throw new Error("Could not find or generate available account!")
+        }
+    }
+    web3.eth.defaultAccount = address;
+    return address;
+}
+
+
+async function startServer(web3, enigmaUrl, contractAddr, scAddr, threshold) {
+    const api = new OperatorApi(web3, enigmaUrl, contractAddr, scAddr, threshold);
     await api.initAsync();
 
     const wss = new WebSocket.Server({port});
@@ -68,4 +91,4 @@ async function startServer(provider, enigmaUrl, contractAddr, scAddr, threshold,
     return api;
 }
 
-module.exports = {startServer, Store};
+module.exports = {configureWeb3Account, startServer, Store};

--- a/operator/src/index.js
+++ b/operator/src/index.js
@@ -14,7 +14,7 @@ const port = process.env.WS_PORT;
 async function configureWeb3Account(web3) {
     let address;
     if (process.env.OPERATOR_ETH_PRIVATE_KEY) {
-        const account = web3.eth.accounts.privateKeyToAccount(process.env.OPERATOR_PRIVATE_KEY);
+        const account = web3.eth.accounts.privateKeyToAccount(process.env.OPERATOR_ETH_PRIVATE_KEY);
         web3.eth.accounts.wallet.add(account);
         address = account.address;
     } else {

--- a/operator/src/miner.js
+++ b/operator/src/miner.js
@@ -2,7 +2,6 @@ require('dotenv').config();
 const Web3 = require('web3');
 const {mineUntilDeal, mineBlock} = require('./ganacheUtils');
 
-const provider = new Web3.providers.HttpProvider(`http://${process.env.ETH_HOST}:${process.env.ETH_PORT}`);
 (async () => {
 
     await mineUntilDeal(web3, server);

--- a/operator/src/secretContractClient.js
+++ b/operator/src/secretContractClient.js
@@ -147,6 +147,7 @@ class SecretContractClient {
         const {taskGasLimit, taskGasPx} = opts;
         const pendingTask = await this.submitTaskAsync(taskFn, taskArgs, taskGasLimit, taskGasPx, this.scAddr);
         const task = await this.waitTaskSuccessAsync(pendingTask);
+        debug('The completed task', task);
         const {taskId} = task;
         debug('Got execute deal task', taskId, 'with results:', {
             encrypted: task.encryptedAbiEncodedOutputs,

--- a/operator/src/secretContractClient.js
+++ b/operator/src/secretContractClient.js
@@ -31,7 +31,7 @@ class SecretContractClient {
     }
 
     getOperatorAccount() {
-        return this.web3.defaultAccount;
+        return this.web3.eth.defaultAccount;
     }
 
     async fetchOutput(task) {

--- a/operator/src/secretContractClient.js
+++ b/operator/src/secretContractClient.js
@@ -21,15 +21,14 @@ class SecretContractClient {
         this.web3 = web3;
     }
 
-    async initAsync(enigmaAddr, enigmaTokenAddr, engOpts) {
+    async initAsync(enigmaAddr, enigmaTokenAddr) {
         this.enigma = new Enigma(
             this.web3,
             enigmaAddr,
             enigmaTokenAddr,
             this.enigmaUrl,
             {
-                gas: engOpts.taskGasLimit,
-                gasPrice: engOpts.taskGasPx,
+                gas: 4712388,
             },
         );
         this.enigma.admin();

--- a/operator/src/secretContractClient.js
+++ b/operator/src/secretContractClient.js
@@ -1,7 +1,5 @@
-const {Enigma, eeConstants} = require('enigma-js/node');
+const {Enigma, eeConstants, utils} = require('enigma-js/node');
 const debug = require('debug')('operator:secret-contract');
-
-const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
 // https://gist.github.com/valentinkostadinov/5875467
 function fromHex(h) {
@@ -58,7 +56,7 @@ class SecretContractClient {
         let gracePeriodInBlocks = 10;
         let previousEpochSize = null;
         do {
-            await sleep(600);
+            await utils.sleep(600);
             const epochSize = parseInt(await this.enigma.enigmaContract.methods.getEpochSize().call());
             if (previousEpochSize && epochSize > previousEpochSize) {
                 if (gracePeriodInBlocks === 0) {
@@ -189,7 +187,7 @@ class SecretContractClient {
                     pubKeySetSuccess = true;
                 } catch (e) {
                     debug('Unable to set pub key on Enigma, submitting a new Task.', e);
-                    await sleep(30000)
+                    await utils.sleep(30000)
                 }
             } while (!pubKeySetSuccess);
             debug('Storing pubKey in cache', this.pubKeyData);

--- a/operator/src/secretContractClient.js
+++ b/operator/src/secretContractClient.js
@@ -84,9 +84,6 @@ class SecretContractClient {
     }
 
     async submitTaskAsync(taskFn, taskArgs, taskGasLimit, taskGasPx, contractAddr) {
-        let balance = await this.enigma.tokenContract.methods.balanceOf(this.getOperatorAccount()).call();
-        debug(`Our ENG balance is: ${balance}`);
-
         return new Promise((resolve, reject) => {
             this.enigma.computeTask(taskFn, taskArgs, taskGasLimit, taskGasPx, this.getOperatorAccount(), contractAddr)
                 .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))

--- a/operator/src/server.js
+++ b/operator/src/server.js
@@ -9,7 +9,7 @@ const {mineUntilDeal} = require('@salad/operator/src/ganacheUtils');
 const args = process.argv;
 const provider = new Web3.providers.HttpProvider(`http://${process.env.ETH_HOST}:${process.env.ETH_PORT}`);
 let server;
-(async () => {
+async function main() {
     const store = new Store();
     await store.initAsync();
 

--- a/operator/src/server.js
+++ b/operator/src/server.js
@@ -6,10 +6,9 @@ const {Store, configureWeb3Account} = require("@salad/operator");
 const {DEPOSITS_COLLECTION, DEALS_COLLECTION, CACHE_COLLECTION} = require('./store');
 const {mineUntilDeal} = require('@salad/operator/src/ganacheUtils');
 
-const args = process.argv;
-const provider = new Web3.providers.HttpProvider(`http://${process.env.ETH_HOST}:${process.env.ETH_PORT}`);
-let server;
 async function main() {
+    const args = process.argv;
+    const provider = new Web3.providers.HttpProvider(`http://${process.env.ETH_HOST}:${process.env.ETH_PORT}`);
     const store = new Store();
     await store.initAsync();
 
@@ -20,7 +19,7 @@ async function main() {
     await store.closeAsync();
     const web3 = new Web3(provider);
     await configureWeb3Account(web3);
-    server = await startServer(web3, enigmaUrl, contractAddr, scAddr, threshold);
+    let server = await startServer(web3, enigmaUrl, contractAddr, scAddr, threshold);
 
     // -t: Truncate db - Truncate the Deposits, Deals and Cache collections
     if (args.indexOf('-t') !== -1) {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -6,7 +6,7 @@ const {utils} = require('enigma-js/node');
 const {mineUntilDeal, mineBlock} = require('@salad/operator/src/ganacheUtils');
 const debug = require('debug')('test');
 const Web3 = require('web3');
-const {Store} = require("@salad/operator");
+const {Store, configureWeb3Account} = require("@salad/operator");
 const {QUORUM_UPDATE} = require("@salad/client").actions;
 
 const {DEALS_COLLECTION, DEPOSITS_COLLECTION, CACHE_COLLECTION} = require('@salad/operator/src/store');
@@ -35,6 +35,7 @@ describe('Salad', () => {
         await store.closeAsync();
 
         const enigmaUrl = `http://${process.env.ENIGMA_HOST}:${process.env.ENIGMA_PORT}`;
+        await configureWeb3Account(web3);
         server = await startServer(web3, enigmaUrl, saladContractAddr, scAddr, threshold);
 
         // Truncating the database

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -59,7 +59,6 @@ describe('Salad', () => {
         // Default options of client-side transactions
         opts = {
             gas: 4712388,
-            gasPrice: 100000000000,
         };
         debug('Environment initialized');
     });

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -30,13 +30,12 @@ describe('Salad', () => {
     before(async () => {
         store = new Store();
         await store.initAsync();
-        const operatorAccountIndex = 0;
         const scAddr = await store.fetchSecretContractAddr();
         saladContractAddr = await store.fetchSmartContractAddr();
         await store.closeAsync();
 
         const enigmaUrl = `http://${process.env.ENIGMA_HOST}:${process.env.ENIGMA_PORT}`;
-        server = await startServer(provider, enigmaUrl, saladContractAddr, scAddr, threshold, operatorAccountIndex);
+        server = await startServer(provider, enigmaUrl, saladContractAddr, scAddr, threshold);
 
         // Truncating the database
         await server.store.truncate(DEPOSITS_COLLECTION);
@@ -45,7 +44,7 @@ describe('Salad', () => {
 
         enigmaContract = server.dealManager.scClient.enigma.enigmaContract;
         const operatorUrl = `ws://localhost:${process.env.WS_PORT}`;
-        salad = new CoinjoinClient(operatorUrl, provider);
+        salad = new CoinjoinClient(operatorUrl, web3);
         // Always shutdown the WS server when tests end
         process.on('SIGINT', async () => {
             debug('Caught interrupt signal, shutting down WS server');

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -35,7 +35,7 @@ describe('Salad', () => {
         await store.closeAsync();
 
         const enigmaUrl = `http://${process.env.ENIGMA_HOST}:${process.env.ENIGMA_PORT}`;
-        server = await startServer(provider, enigmaUrl, saladContractAddr, scAddr, threshold);
+        server = await startServer(web3, enigmaUrl, saladContractAddr, scAddr, threshold);
 
         // Truncating the database
         await server.store.truncate(DEPOSITS_COLLECTION);


### PR DESCRIPTION
The operator codebase no longer assumes that it has access to accounts, but rather tries to set a default account for  web3 connection when initializing it. This account is either from a private key passed in as the OPERATOR_ETH_PRIVATE_KEY variable, or fetched from the list of unlocked accounts on ethereum node providing the connection to the ethereum network. no address could be generated using the described method, an error thrown.

EDIT: this task has grown somewhat while waiting to be merged, as it was a blocker to running operator on our testnet. The notable modifications beyond the original goal are:
* CoinjoinClient, OperatorApi, and startServer now take a Web3 instance instead of a Provider.
* an update to gas prices.
* several minor bug fixes.
* general cleanup of a few areas of the code inspected during debugging.