### PR TITLE
mdemri-enigma-js

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "core-js": "^3.4.5",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",
-    "enigma-js": "0.3.0",
+    "@mdemri/enigma-js": "0.3.0",
     "eth-crypto": "^1.5.0",
     "eth-sig-util": "^2.5.1",
     "mongodb": "^3.3.5",

--- a/operator/package.json
+++ b/operator/package.json
@@ -7,7 +7,7 @@
     "@salad/client": "0.1.0",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",
-    "enigma-js": "0.3.0",
+    "@mdemri/enigma-js": "0.3.0",
     "eth-sig-util": "^2.5.1",
     "mongodb": "^3.3.5",
     "node-forge": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "core-js": "^3.4.5",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",
-    "enigma-js": "0.3.0",
+    "@mdemri/enigma-js": "0.3.0",
     "openzeppelin-solidity": "^2.4.0",
     "supports-color": "^7.1.0"
   },


### PR DESCRIPTION
changing Operator to depend on @mdemri's npm package, which is built from a newer version of enigmampc/enigma-contract than the default npm package