### PR TITLE
updated a call to Enigma.obtainTaskKeyPair to match the definition in enigmampc/enigma-contract/enigma-js

### DIFF
--- a/operator/src/secretContractClient.js
+++ b/operator/src/secretContractClient.js
@@ -93,16 +93,14 @@ class SecretContractClient {
         const taskFn = 'get_pub_key()';
         const taskArgs = [];
         const {taskGasLimit, taskGasPx} = opts;
-        const sender = this.getOperatorAccount();
-        const keyPair = this.enigma.obtainTaskKeyPair(
-            sender,
-            await this.enigma.enigmaContract.methods.getUserTaskDeployments(sender).call(),
-        );
-        debug('The key pair', keyPair);
         debug('submitTaskAsync(', taskFn, taskArgs, taskGasLimit, taskGasPx, this.getOperatorAccount(), this.scAddr, ')');
         const pendingTask = await this.submitTaskAsync(taskFn, taskArgs, taskGasLimit, taskGasPx, this.scAddr);
         let task = await this.waitTaskSuccessAsync(pendingTask);
         debug('The completed task', task);
+
+        const sender = this.getOperatorAccount();
+        const keyPair = this.enigma.obtainTaskKeyPair(sender, task.nonce);
+        debug('The key pair for the task was', keyPair);
 
         this.pubKeyData = {
             taskId: task.taskId,

--- a/operator/src/secretContractClient.js
+++ b/operator/src/secretContractClient.js
@@ -93,7 +93,11 @@ class SecretContractClient {
         const taskFn = 'get_pub_key()';
         const taskArgs = [];
         const {taskGasLimit, taskGasPx} = opts;
-        const keyPair = this.enigma.obtainTaskKeyPair();
+        const sender = this.getOperatorAccount();
+        const keyPair = this.enigma.obtainTaskKeyPair(
+            sender,
+            await this.enigma.enigmaContract.methods.getUserTaskDeployments(sender).call(),
+        );
         debug('The key pair', keyPair);
         debug('submitTaskAsync(', taskFn, taskArgs, taskGasLimit, taskGasPx, this.getOperatorAccount(), this.scAddr, ')');
         const pendingTask = await this.submitTaskAsync(taskFn, taskArgs, taskGasLimit, taskGasPx, this.scAddr);


### PR DESCRIPTION
The code  now calls `Enigma.obtainTaskKeyPair()` with the two arguments excpected on the `develop` branch of `enigmampc/enigma-contract/enigma-js`. ~I argue that the change in enigma-js is incorrect and should be changed. I will discuss this with the relevant team members when they return from the weekend, so untill then please do not merge this PR.~ EDIT: this deleted part is now irrelevant after finding i was doing it wrong :) fixed in the second commit of this PR.

This PR may fail CI because the CI still uses the enigma-js version published to npm.

CC: https://github.com/enigmampc/docker-environment/pull/71